### PR TITLE
bug fix #18 - ignoring errors when .kw.yml config does not exist

### DIFF
--- a/pkg/config/kubewide.go
+++ b/pkg/config/kubewide.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -38,6 +39,9 @@ func NewKubeWideConfig() (*KubeWideConfig, error) {
 
 	err = cc.read()
 	if err != nil {
+		if _, ok := errors.Cause(err).(*os.PathError); ok {
+			return cc, nil
+		}
 		return nil, err
 	}
 
@@ -50,7 +54,6 @@ func (c *KubeWideConfig) path() error {
 		var err error
 		c.pathname, err = homedir.Expand(defaultPath)
 		if err != nil {
-			return fmt.Errorf("could not define the default path: %w", err)
 		}
 	}
 
@@ -60,7 +63,7 @@ func (c *KubeWideConfig) path() error {
 func (c *KubeWideConfig) read() error {
 	f, err := ioutil.ReadFile(c.pathname)
 	if err != nil {
-		return fmt.Errorf("error reading the kw config file: %w", err)
+		return errors.Wrapf(err, "error reading the kw config file: %s", c.pathname)
 	}
 	return yaml.Unmarshal(f, c)
 }


### PR DESCRIPTION
Using errors.Wrapf instead of fmt.Errorf to allow us to get the cause of the error and use type assertions to verify if the error is due a missing file
This PR should solve issue #18 