### PR TITLE
Fix the gosec rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@
 # Install the dependencies of build
 
 setup:
-	@go get golang.org/x/lint/golint
-	@go get golang.org/x/tools/cmd/goimports
-	@go get github.com/securego/gosec/cmd/gosec
+	@go get golang.org/x/lint/golint@v0.0.0-20200302205851-738671d3881b
+	@go get golang.org/x/tools/cmd/goimports@v0.0.0-20200402223321-bcf690261a44
+	@go get github.com/securego/gosec/cmd/gosec@v0.0.0-20200401082031-e946c8c39989
 
 # Check quality of code
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/ktr0731/go-fuzzyfinder v0.2.0
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.7
 	github.com/stretchr/testify v1.5.1
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -565,6 +565,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1XfZvZ13m8mub3shuVftRs0=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/config/kubewide.go
+++ b/pkg/config/kubewide.go
@@ -75,7 +75,7 @@ func (c *KubeWideConfig) Write() error {
 		return fmt.Errorf("error writing the kw config file: %w", err)
 	}
 
-	return ioutil.WriteFile(c.pathname, b, 0644)
+	return ioutil.WriteFile(c.pathname, b, 0600)
 }
 
 // PreviousContext returns the previous context, otherwise empty


### PR DESCRIPTION
The version of go tools, including gosec, was not defined in the
Makefile; so the latest version was downloaded. The latest
version of gosec contains a new alert that is breaking our build.
I fixed it.

To avoid the same issue in the future, we are defining a specific
version for all go tools.

It also includes a dependency on go.mod (import added in the last
commit).

Fixes https://github.com/leocomelli/kw/issues/17